### PR TITLE
Add outdated whitepaper information

### DIFF
--- a/components/WhitepaperRedirect/index.tsx
+++ b/components/WhitepaperRedirect/index.tsx
@@ -1,0 +1,72 @@
+import Container from '@/components/Container';
+import classNames from 'classnames';
+import { useRouter } from 'next/router';
+import { Button } from '@/components/ui';
+
+export default function WhitepaperRedirect() {
+  const router = useRouter();
+  return (
+    <section>
+      <Container
+        heights={{
+          small: '100vh - 108px',
+          medium: '50vh',
+          large: '40vh',
+          huge: '50vh',
+          enormous: '50vh',
+        }}
+        classes={classNames(
+          'py-16 px-2 mx-auto text-center',
+          'md:flex md:flex-col md:justify-center md:items-center'
+        )}
+      >
+        <h1 className={classNames('text-primary-dark text-4xl font-bold mb-8')}>
+          Outdated content!
+        </h1>
+        <p
+          className={classNames('text-gray')}
+        >
+		  Since the writing of this whitepaper, Session has undergone several protocol changes in order to be faster and more sustainable, so some information in this document is outdated.<br/>
+		  
+		  While the team works on an updated document, please refer to the{' '}
+          <button
+            className="font-semibold text-primary-dark"
+            onClick={() => router.push("/lightpaper")}
+          >
+            lightpaper
+          </button>
+           , the {' '}
+          <button
+            className="font-semibold text-primary-dark"
+            onClick={() => router.push("/blog")}
+          >
+            blog
+          </button>{' '} 
+          or the {' '}
+          <button
+            className="font-semibold text-primary-dark"
+            onClick={() => router.push("/faq")}
+          >
+            FAQ
+          </button>{' '}
+          for more up-to-date information.
+        </p>
+        
+        <br/>
+
+        <Button
+          className="ml-6" fontWeight="bold"
+          onClick={() => router.push("https://arxiv.org/pdf/2002.04609.pdf")}
+        >
+          Continue to the Whitepaper
+        </Button>
+        <button
+          className="font-semibold text-primary-dark"
+          onClick={() => router.back()}
+        >
+          Back
+        </button>
+      </Container>
+    </section>
+  );
+}

--- a/constants/navigation.ts
+++ b/constants/navigation.ts
@@ -40,8 +40,7 @@ const NAV_ITEMS: INavList = {
       Whitepaper: {
         href: '/whitepaper',
         alt: 'Link to Session Whitepaper',
-        target: '_blank',
-        rel: 'noopener noreferrer',
+        target: '_self',
       },
       Documentation: {
         href: 'https://docs.oxen.io/products-built-on-oxen/session',

--- a/next.config.js
+++ b/next.config.js
@@ -105,11 +105,6 @@ const config = {
         destination: 'https://fdroid.getsession.org/',
         permanent: true,
       },
-      {
-        source: '/whitepaper',
-        destination: 'https://arxiv.org/pdf/2002.04609.pdf',
-        permanent: true,
-      },
     ],
   },
   async redirects() {

--- a/pages/whitepaper.tsx
+++ b/pages/whitepaper.tsx
@@ -1,0 +1,13 @@
+import { ReactElement, useEffect } from 'react';
+
+import { Layout } from '@/components/ui';
+import { METADATA } from '@/constants';
+import WhitepaperRedirect from '@/components/WhitepaperRedirect';
+
+export default function Whitepaper(): ReactElement {
+  return (
+    <Layout title="Whitepaper" metadata={METADATA.LIGHTPAPER_PAGE}>
+      <WhitepaperRedirect />
+    </Layout>
+  );
+}


### PR DESCRIPTION
I've seen many users concerned about the discrepancies between the contents of the whitepaper and what has been told to them via the FAQ or in Session groups.
This PR aims to reduce confusion by clarifying that the whitepaper is out of date. I think it can be very beneficial to the end users.
Let me know if anything needs to be changed.